### PR TITLE
Integrate ULX banned/allowed maps

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported license.
+
+Basically,
+You are free:
+to Share — to copy, distribute and transmit the work
+to Remix — to adapt the work
+
+
+Under the following conditions:
+Attribution — You must attribute the work in the manner specified by the author or licensor (but not in any way that suggests that they endorse you or your use of the work).
+Noncommercial — You may not use this work for commercial purposes.
+Share Alike — If you alter, transform, or build upon this work, you may distribute the resulting work only under the same or similar license to this one.
+
+With the understanding that:
+Waiver — Any of the above conditions can be waived if you get permission from the copyright holder.
+Public Domain — Where the work or any of its elements is in the public domain under applicable law, that status is in no way affected by the license.
+Other Rights — In no way are any of the following rights affected by the license:
+Your fair dealing or fair use rights, or other applicable copyright exceptions and limitations;
+The author's moral rights;
+Rights other persons may have either in the work itself or in how the work is used, such as publicity or privacy rights.
+Notice — For any reuse or distribution, you must make clear to others the license terms of this work. The best way to do this is with a link to this web page.
+
+
+How to give Attribution:
+Include a mention of Willox ( http://steamcommunity.com/id/Willox303 ), the original author and a link to the original facepunch thread ( http://facepunch.com/showthread.php?t=1268353 )
+Include a mention of Tyrantelf and a link to the github repository ( https://github.com/tyrantelf/gmod-mapvote )
+
+
+Full license can be read here: http://creativecommons.org/licenses/by-nc-sa/3.0/legalcode

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+Simple Map Voting Addon
+=======================
+
+Information available on facepunch thread: http://facepunch.com/showthread.php?t=1268353
+

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Usage
 
 Starting a vote from within lua is rather simple.
 
-```lua
+```Lua
 MapVote.Start(voteLength, allowCurrentMap, mapLimit, mapPrefix)
 ```
 All arguments to this function are optional and the map prefix is acquired from the config, or if it isn't set, gamemode.txt file if available. You can also set up defaults within garrysmod/data/mapvote/config.txt which is generated during the first run.
 
 It is also possible to cancel map votes from within lua with:
-```lua
+```Lua
 MapVote.Cancel()
 ```
 
@@ -27,7 +27,7 @@ You can give players extra voting power in lua/autorun/mapvote.lua with the MapV
 TTT Setup
 =======================
 Simply put, you can do this by finding the following code in gamemodes/terrortown/gamemode/init.lua (around line 726)
-```
+```Lua
    if switchmap then
       timer.Stop("end2prep")
       timer.Simple(15, game.LoadNextMap)
@@ -39,7 +39,7 @@ Simply put, you can do this by finding the following code in gamemodes/terrortow
 ```
 
 and replacing it with
-```
+```Lua
    if switchmap then
       timer.Stop("end2prep")
       MapVote.Start(15, false, 24, "ttt_")
@@ -53,13 +53,13 @@ and replacing it with
 This will cause a map vote at the end of the round, based on the settings defined in your config.txt
 
 If you plan on using more than one map prefix, you can edit the config.txt.  It look like this by default:
-```
+```JSON
 {"MapPrefixes":{"1":"ttt_"},"MapLimit":24,"TimeLimit":28,"AllowCurrentMap":false,"MapsBeforeRevote":3,"EnableCooldown":true}
 ```
 "MapsBeforeRevote" is how many maps before the map is taken off the cooldown list after it's played.
 
 To add more Map Prefixes, do this:
-```
+```JSON
 {"MapPrefixes":{"1":"ttt_","2":"zm_","3":"de_"},"MapLimit":24,"TimeLimit":28,"AllowCurrentMap":false,"MapsBeforeRevote":3,"EnableCooldown":true}
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ You can edit the config.txt located in garrysmod/data/mapvote/ to change several
 * "MapsBeforeRevote" is how many maps before the map is taken off the cooldown list after it's played.
 
 To add more Map Prefixes, do this: 
-```JSON {"RTVPlayerCount":3,"MapLimit":24,"TimeLimit":28,"AllowCurrentMap":false,"MapPrefixes":{"1":"ttt_","2":"zm_","3":"de_"},"MapsBeforeRevote":3,"EnableCooldown":true}```
+```JSON
+{"RTVPlayerCount":3,"MapLimit":24,"TimeLimit":28,"AllowCurrentMap":false,"MapPrefixes":{"1":"ttt_","2":"zm_","3":"de_"},"MapsBeforeRevote":3,"EnableCooldown":true}
+```
 
 Modifications
 =======================

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Modifications
 Featuress added made by others:
 * RTV Implimentation by [Eccid](http://facepunch.com/member.php?u=536187)
 * ULX integration by [Ambro](http://facepunch.com/member.php?u=555824)
+* RTV vote delay to end of TTT and Deathrun rounds (Thanks Again, Willox!)
 
 My Feature Additions:
 * CoolDown System
@@ -61,5 +62,5 @@ My Feature Additions:
 * Automatically working with TTT and Deathun
 
 Planned Feature Additions:
-* RTV vote delay to end of TTT rounds (With config enable/disable)
+* Enable/Disable on RTV delay to round end on TTT and Deathrun
 * Config to give extra voting power

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ It recieved many suggestions and additions in it's [original facepunch thread](h
 
 This is my version which takes many of the additions and suggestions, and impliements them in one, simple, configurable addon.
 
+[You can also get this addon through steam workshop!](http://steamcommunity.com/sharedfiles/filedetails/?id=151583504)
+
 Usage
 =======================
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 MapVote
 =======================
 
-MapVote is a wonderful little GMOD13 addon origionally made by [Willox](http://steamcommunity.com/id/Willox303) that allows you to easily invoke a map vote from within any gamemode of your choosing.
+MapVote is a wonderful little GMOD13 addon originally made by [Willox](http://steamcommunity.com/id/Willox303) that allows you to easily invoke a map vote from within any gamemode of your choosing.
 
-It recieved many suggestions and additions in it's [origional facepunch thread](http://facepunch.com/showthread.php?t=1268353).
+It recieved many suggestions and additions in it's [original facepunch thread](http://facepunch.com/showthread.php?t=1268353).
 
 This is my version which takes many of the additions and suggestions, and impliements them in one, simple, configurable addon.
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,8 @@ You can edit the config.txt located in garrysmod/data/mapvote/ to change several
 * "EnableCooldown" is a true/false variable on whether to remove a map from voting for a while after it's played.
 * "MapsBeforeRevote" is how many maps before the map is taken off the cooldown list after it's played.
 
-To add more Map Prefixes, do this: ```JSON
-{"RTVPlayerCount":3,"MapLimit":24,"TimeLimit":28,"AllowCurrentMap":false,"MapPrefixes":{"1":"ttt_","2":"zm_","3":"de_"},"MapsBeforeRevote":3,"EnableCooldown":true}
-```
+To add more Map Prefixes, do this: 
+```JSON {"RTVPlayerCount":3,"MapLimit":24,"TimeLimit":28,"AllowCurrentMap":false,"MapPrefixes":{"1":"ttt_","2":"zm_","3":"de_"},"MapsBeforeRevote":3,"EnableCooldown":true}```
 
 Modifications
 =======================

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ and replacing it with
 ```Lua
    if switchmap then
       timer.Stop("end2prep")
-      MapVote.Start(15, false, 24, "ttt_")
+      MapVote.Start(nil, nil, nil, nil)
    elseif ShouldMapSwitch() then
       LANG.Msg("limit_left", {num = rounds_left,
                               time = math.ceil(time_left / 60),

--- a/README.md
+++ b/README.md
@@ -24,43 +24,28 @@ MapVote.Cancel()
 
 You can give players extra voting power in lua/autorun/mapvote.lua with the MapVote.HasExtraVotePower function, and a config will be added at some point.
 
-TTT Setup
+TTT and Deathrun Setup
 =======================
-Simply put, you can do this by finding the following code in gamemodes/terrortown/gamemode/init.lua (around line 726)
-```Lua
-   if switchmap then
-      timer.Stop("end2prep")
-      timer.Simple(15, game.LoadNextMap)
-   elseif ShouldMapSwitch() then
-      LANG.Msg("limit_left", {num = rounds_left,
-                              time = math.ceil(time_left / 60),
-                              mapname = nextmap})
-   end
-```
 
-and replacing it with
-```Lua
-   if switchmap then
-      timer.Stop("end2prep")
-      MapVote.Start(nil, nil, nil, nil)
-   elseif ShouldMapSwitch() then
-      LANG.Msg("limit_left", {num = rounds_left,
-                              time = math.ceil(time_left / 60),
-                              mapname = "chosen by a vote"})
-   end
-```
+You no longer have to edit any files for MapVote to work with Trouble in Terrorist Town or Deathrun anymore!  It now overrides the default functions for map switching.
 
-This will cause a map vote at the end of the round, based on the settings defined in your config.txt
+*Note: On Deathrun, it still uses the build in RTV, so changing the minimum player count doesn't work*
 
-If you plan on using more than one map prefix, you can edit the config.txt.  It look like this by default:
+You can edit the config.txt located in garrysmod/data/mapvote/ to change several settings.  It should look like this by default (if it's empty, just copy this into it):
 ```JSON
-{"MapPrefixes":{"1":"ttt_"},"MapLimit":24,"TimeLimit":28,"AllowCurrentMap":false,"MapsBeforeRevote":3,"EnableCooldown":true}
+{"RTVPlayerCount":3,"MapLimit":24,"TimeLimit":28,"AllowCurrentMap":false,"MapPrefixes":{"1":"ttt_"},"MapsBeforeRevote":3,"EnableCooldown":true}
 ```
-"MapsBeforeRevote" is how many maps before the map is taken off the cooldown list after it's played.
+* "RTVPlayerCount" is the minimum number of players that need to be online (on TTT) for RTV to work.
+* "MapLimit" is the number of maps shown on the vote screen.
+* "TimeLimit" is how long the vote is shown for.
+* "AllowCurrentMap" true/false to allow a the current map in the map vote list.
+* "MapPrefixes" are the prefixes of the maps that should be used in the vote.
+* "MapsBeforeRevote" is the number of maps that must be played before a map is in the vote menu again (if EnableCooldown is true)
+* "EnableCooldown" is a true/false variable on whether to remove a map from voting for a while after it's played.
+* "MapsBeforeRevote" is how many maps before the map is taken off the cooldown list after it's played.
 
-To add more Map Prefixes, do this:
-```JSON
-{"MapPrefixes":{"1":"ttt_","2":"zm_","3":"de_"},"MapLimit":24,"TimeLimit":28,"AllowCurrentMap":false,"MapsBeforeRevote":3,"EnableCooldown":true}
+To add more Map Prefixes, do this: ```JSON
+{"RTVPlayerCount":3,"MapLimit":24,"TimeLimit":28,"AllowCurrentMap":false,"MapPrefixes":{"1":"ttt_","2":"zm_","3":"de_"},"MapsBeforeRevote":3,"EnableCooldown":true}
 ```
 
 Modifications
@@ -72,8 +57,8 @@ Featuress added made by others:
 My Feature Additions:
 * CoolDown System
 * JSON config that auto-generates at garrysmod/data/mapvote/config.txt
+* Automatically working with TTT and Deathun
 
 Planned Feature Additions:
-* Automatically working with TTT
 * RTV vote delay to end of TTT rounds (With config enable/disable)
 * Config to give extra voting power

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 Simple Map Voting Addon
 =======================
 
+Modifed by Tyrantelf of IonGaming.org
+
+
 Information available on facepunch thread: http://facepunch.com/showthread.php?t=1268353
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,79 @@
-Simple Map Voting Addon
+MapVote
 =======================
 
-Modifed by Tyrantelf of IonGaming.org
+MapVote is a wonderful little GMOD13 addon origionally made by [Willox](http://steamcommunity.com/id/Willox303) that allows you to easily invoke a map vote from within any gamemode of your choosing.
 
+It recieved many suggestions and additions in it's [origional facepunch thread](http://facepunch.com/showthread.php?t=1268353).
 
-Information available on facepunch thread: http://facepunch.com/showthread.php?t=1268353
+This is my version which takes many of the additions and suggestions, and impliements them in one, simple, configurable addon.
 
+Usage
+=======================
+
+Starting a vote from within lua is rather simple.
+
+```lua
+MapVote.Start(voteLength, allowCurrentMap, mapLimit, mapPrefix)
+```
+All arguments to this function are optional and the map prefix is acquired from the config, or if it isn't set, gamemode.txt file if available. You can also set up defaults within garrysmod/data/mapvote/config.txt which is generated during the first run.
+
+It is also possible to cancel map votes from within lua with:
+```lua
+MapVote.Cancel()
+```
+
+You can give players extra voting power in lua/autorun/mapvote.lua with the MapVote.HasExtraVotePower function, and a config will be added at some point.
+
+TTT Setup
+=======================
+Simply put, you can do this by finding the following code in gamemodes/terrortown/gamemode/init.lua (around line 726)
+```
+   if switchmap then
+      timer.Stop("end2prep")
+      timer.Simple(15, game.LoadNextMap)
+   elseif ShouldMapSwitch() then
+      LANG.Msg("limit_left", {num = rounds_left,
+                              time = math.ceil(time_left / 60),
+                              mapname = nextmap})
+   end
+```
+
+and replacing it with
+```
+   if switchmap then
+      timer.Stop("end2prep")
+      MapVote.Start(15, false, 24, "ttt_")
+   elseif ShouldMapSwitch() then
+      LANG.Msg("limit_left", {num = rounds_left,
+                              time = math.ceil(time_left / 60),
+                              mapname = "chosen by a vote"})
+   end
+```
+
+This will cause a map vote at the end of the round, based on the settings defined in your config.txt
+
+If you plan on using more than one map prefix, you can edit the config.txt.  It look like this by default:
+```
+{"MapPrefixes":{"1":"ttt_"},"MapLimit":24,"TimeLimit":28,"AllowCurrentMap":false,"MapsBeforeRevote":3,"EnableCooldown":true}
+```
+"MapsBeforeRevote" is how many maps before the map is taken off the cooldown list after it's played.
+
+To add more Map Prefixes, do this:
+```
+{"MapPrefixes":{"1":"ttt_","2":"zm_","3":"de_"},"MapLimit":24,"TimeLimit":28,"AllowCurrentMap":false,"MapsBeforeRevote":3,"EnableCooldown":true}
+```
+
+Modifications
+=======================
+Featuress added made by others:
+* RTV Implimentation by [Eccid](http://facepunch.com/member.php?u=536187)
+* ULX integration by [Ambro](http://facepunch.com/member.php?u=555824)
+
+My Feature Additions:
+* CoolDown System
+* JSON config that auto-generates at garrysmod/data/mapvote/config.txt
+
+Planned Feature Additions:
+* Automatically working with TTT
+* RTV vote delay to end of TTT rounds (With config enable/disable)
+* Config to give extra voting power

--- a/addon.txt
+++ b/addon.txt
@@ -1,0 +1,10 @@
+"AddonInfo"
+{
+	"name"			"MapVote"
+	"version"		"1.0"
+	"up_date"		""
+	"author_name"	"Willox & Dizla (a little bit)"
+	"author_email"	"me@willox.tv"
+	"author_url"	"http://resonance-gaming.co.uk/"
+	"info"			"http://resonance-gaming.co.uk/"
+}

--- a/addon.txt
+++ b/addon.txt
@@ -1,10 +1,10 @@
 "AddonInfo"
 {
 	"name"			"MapVote"
-	"version"		"1.0"
+	"version"		"1.1"
 	"up_date"		""
-	"author_name"	"Willox & Dizla (a little bit)"
-	"author_email"	"me@willox.tv"
-	"author_url"	"http://resonance-gaming.co.uk/"
-	"info"			"http://resonance-gaming.co.uk/"
+	"author_name"	"Tyrantelf (Origional: Willox & Dizla (a little bit))"
+	"author_email"	"tyrantelf@iongaming.org"
+	"author_url"	"http://iongaming.org/"
+	"info"			"http://iongaming.org/"
 }

--- a/lua/autorun/mapvote.lua
+++ b/lua/autorun/mapvote.lua
@@ -8,6 +8,7 @@ MapVote.Config = {}
         AllowCurrentMap = false,
         EnableCooldown = true,
         MapsBeforeRevote = 3,
+        MapPrefixes = "{"ttt_"}"
     }
 -- CONFIG
 
@@ -36,6 +37,7 @@ if SERVER then
     AddCSLuaFile("mapvote/cl_mapvote.lua")
 
     include("mapvote/sv_mapvote.lua")
+    include("mapvote/rtv.lua")
 else
     include("mapvote/cl_mapvote.lua")
 end

--- a/lua/autorun/mapvote.lua
+++ b/lua/autorun/mapvote.lua
@@ -9,11 +9,11 @@ MapVote.Config = {}
     }
 -- CONFIG
 
-function MapVote.HasExtraMapVotePower(ply)
--- Example that gives admins more voting power
--- if ply:IsAdmin() then
---		return true
---	end
+function MapVote.HasExtraVotePower(ply)
+	-- Example that gives admins more voting power
+	if ply:IsAdmin() then
+		return true
+	end
 
 	return false
 end

--- a/lua/autorun/mapvote.lua
+++ b/lua/autorun/mapvote.lua
@@ -2,14 +2,26 @@ MapVote = {}
 MapVote.Config = {}
 
 -- CONFIG
-    MapVote.Config = {
+    MapVote.Config.Default = {
         MapLimit = 24,
         TimeLimit = 28,
         AllowCurrentMap = false,
         EnableCooldown = true,
         MapsBeforeRevote = 3,
+        MapPrefixes = {"ttt_"},
     }
 -- CONFIG
+
+hook.Add( "Initialize", "MapVoteConfig", function()
+    if not file.Exists( "mapvote", "DATA") then
+        file.CreateDir( "mapvote" )
+    end
+    if file.Exists( "mapvote/config.txt", "DATA" ) then
+        MapVote.Config = util.JSONToTable(file.Read("mapvote/config.txt", "DATA"))
+    else
+        file.Write("mapvote/config.txt", util.TableToJSON(MapVote.Config.Default))
+    end
+end )
 
 function MapVote.HasExtraVotePower(ply)
 	-- Example that gives admins more voting power

--- a/lua/autorun/mapvote.lua
+++ b/lua/autorun/mapvote.lua
@@ -6,14 +6,18 @@ MapVote.Config = {}
         MapLimit = 24,
         TimeLimit = 28,
         AllowCurrentMap = false,
+        EnableCooldown = true,
+        MapsBeforeRevote = 3,
     }
 -- CONFIG
 
 function MapVote.HasExtraVotePower(ply)
 	-- Example that gives admins more voting power
-	if ply:IsAdmin() then
+	--[[
+    if ply:IsAdmin() then
 		return true
-	end
+	end 
+    ]]
 
 	return false
 end

--- a/lua/autorun/mapvote.lua
+++ b/lua/autorun/mapvote.lua
@@ -1,14 +1,13 @@
 MapVote = {}
 MapVote.Config = {}
 
--- CONFIG (sort of)
+-- CONFIG
     MapVote.Config = {
         MapLimit = 24,
         TimeLimit = 28,
         AllowCurrentMap = false,
         EnableCooldown = true,
         MapsBeforeRevote = 3,
-        MapPrefixes = "{"ttt_"}"
     }
 -- CONFIG
 

--- a/lua/autorun/mapvote.lua
+++ b/lua/autorun/mapvote.lua
@@ -10,7 +10,7 @@ MapVoteConfigDefault = {
     MapsBeforeRevote = 3,
     RTVPlayerCount = 3,
     MapPrefixes = {"ttt_"},
-    AutoGamemode = true
+    AutoGamemode = false
 }
 --Default Config
 

--- a/lua/autorun/mapvote.lua
+++ b/lua/autorun/mapvote.lua
@@ -9,6 +9,7 @@ MapVote.Config = {}
         EnableCooldown = true,
         MapsBeforeRevote = 3,
         MapPrefixes = {"ttt_"},
+        RTVPlayerCount = 3,
     }
 -- CONFIG
 

--- a/lua/autorun/mapvote.lua
+++ b/lua/autorun/mapvote.lua
@@ -1,24 +1,24 @@
 MapVote = {}
 MapVote.Config = {}
 
--- CONFIG
-    MapVote.Config.Default = {
-        MapLimit = 24,
-        TimeLimit = 28,
-        AllowCurrentMap = false,
-        EnableCooldown = true,
-        MapsBeforeRevote = 3,
-        MapPrefixes = {"ttt_"},
-        RTVPlayerCount = 3,
+--Default Config
+MapVoteConfigDefault = {
+    MapLimit = 24,
+    TimeLimit = 28,
+    AllowCurrentMap = false,
+    EnableCooldown = true,
+    MapsBeforeRevote = 3,
+    RTVPlayerCount = 3,
+    MapPrefixes = {"ttt_"}
     }
--- CONFIG
+--Default Config
 
-hook.Add( "Initialize", "MapVoteConfig", function()
+hook.Add( "Initialize", "MapVoteConfigSetup", function()
     if not file.Exists( "mapvote", "DATA") then
         file.CreateDir( "mapvote" )
     end
     if not file.Exists( "mapvote/config.txt", "DATA" ) then
-        file.Write("mapvote/config.txt", util.TableToJSON(MapVote.Config.Default))
+        file.Write( "mapvote/config.txt", util.TableToJSON( MapVoteConfigDefault ) )
     end
 end )
 

--- a/lua/autorun/mapvote.lua
+++ b/lua/autorun/mapvote.lua
@@ -1,0 +1,37 @@
+MapVote = {}
+MapVote.Config = {}
+
+-- CONFIG (sort of)
+    MapVote.Config = {
+        MapLimit = 24,
+        TimeLimit = 28,
+        AllowCurrentMap = false,
+    }
+-- CONFIG
+
+function MapVote.HasExtraMapVotePower(ply)
+-- Example that gives admins more voting power
+-- if ply:IsAdmin() then
+--		return true
+--	end
+
+	return false
+end
+
+
+MapVote.CurrentMaps = {}
+MapVote.Votes = {}
+
+MapVote.Allow = false
+
+MapVote.UPDATE_VOTE = 1
+MapVote.UPDATE_WIN = 3
+
+if SERVER then
+    AddCSLuaFile()
+    AddCSLuaFile("mapvote/cl_mapvote.lua")
+
+    include("mapvote/sv_mapvote.lua")
+else
+    include("mapvote/cl_mapvote.lua")
+end

--- a/lua/autorun/mapvote.lua
+++ b/lua/autorun/mapvote.lua
@@ -16,9 +16,7 @@ hook.Add( "Initialize", "MapVoteConfig", function()
     if not file.Exists( "mapvote", "DATA") then
         file.CreateDir( "mapvote" )
     end
-    if file.Exists( "mapvote/config.txt", "DATA" ) then
-        MapVote.Config = util.JSONToTable(file.Read("mapvote/config.txt", "DATA"))
-    else
+    if not file.Exists( "mapvote/config.txt", "DATA" ) then
         file.Write("mapvote/config.txt", util.TableToJSON(MapVote.Config.Default))
     end
 end )

--- a/lua/autorun/server/sv_autovote.lua
+++ b/lua/autorun/server/sv_autovote.lua
@@ -28,6 +28,13 @@ hook.Add( "Initialize", "AutoTTTMapVote", function()
             MapVote.Start(nil, nil, nil, nil)
           end
       end
+      
+      if GAMEMODE_NAME == "zombiesurvival" then
+        function GM:LoadNextMap()
+          MapVote.Start(nil, nil, nil, nil)
+        end
+      end
+
 end )
 
 

--- a/lua/autorun/server/sv_autovote.lua
+++ b/lua/autorun/server/sv_autovote.lua
@@ -30,9 +30,10 @@ hook.Add( "Initialize", "AutoTTTMapVote", function()
       end
       
       if GAMEMODE_NAME == "zombiesurvival" then
-        function GAMEMODE:LoadNextMap()
+        hook.Add("LoadNextMap", "MAPVOTEZS_LOADMAP", function()
           MapVote.Start(nil, nil, nil, nil)
-        end
+          return true   
+        end )
       end
 
 end )

--- a/lua/autorun/server/sv_autovote.lua
+++ b/lua/autorun/server/sv_autovote.lua
@@ -30,7 +30,7 @@ hook.Add( "Initialize", "AutoTTTMapVote", function()
       end
       
       if GAMEMODE_NAME == "zombiesurvival" then
-        function GM:LoadNextMap()
+        function GAMEMODE:LoadNextMap()
           MapVote.Start(nil, nil, nil, nil)
         end
       end

--- a/lua/autorun/server/sv_autovote.lua
+++ b/lua/autorun/server/sv_autovote.lua
@@ -1,4 +1,5 @@
 hook.Add( "Initialize", "AutoTTTMapVote", function()
+      if GAMEMODE_NAME == "terrortown" then
         function CheckForMapSwitch()
            -- Check for mapswitch
            local rounds_left = math.max(0, GetGlobalInt("ttt_rounds_left", 6) - 1)
@@ -15,9 +16,18 @@ hook.Add( "Initialize", "AutoTTTMapVote", function()
               LANG.Msg("limit_time", {mapname = nextmap})
               switchmap = true
             end
-            if GAMEMODE_NAME == "terrortown" and switchmap then
+            if switchmap then
                 timer.Stop("end2prep")
                 MapVote.Start(nil, nil, nil, nil)
             end
         end
+      end
+      
+      if GAMEMODE_NAME == "deathrun" then
+          function RTV.Start()
+            MapVote.Start(nil, nil, nil, nil)
+          end
+      end
 end )
+
+

--- a/lua/autorun/server/sv_tttvote.lua
+++ b/lua/autorun/server/sv_tttvote.lua
@@ -1,0 +1,29 @@
+hook.Add( "Initialize", "RTV", function()
+        function CheckForMapSwitch()
+           -- Check for mapswitch
+           local rounds_left = math.max(0, GetGlobalInt("ttt_rounds_left", 6) - 1)
+           SetGlobalInt("ttt_rounds_left", rounds_left)
+ 
+           local time_left = math.max(0, (GetConVar("ttt_time_limit_minutes"):GetInt() * 60) - CurTime())
+           local switchmap = false
+           local nextmap = string.upper(game.GetMapNext())
+ 
+            if rounds_left <= 0 then
+              LANG.Msg("limit_round", {mapname = nextmap})
+              switchmap = true
+            elseif time_left <= 0 then
+              LANG.Msg("limit_time", {mapname = nextmap})
+              switchmap = true
+            end
+            if GAMEMODE_NAME == "terrortown" then
+              if switchmap then
+                timer.Stop("end2prep")
+                MapVote.Start(nil, nil, nil, nil)
+              elseif ShouldMapSwitch() then
+                    LANG.Msg("limit_left", {num = rounds_left,
+                              time = math.ceil(time_left / 60),
+                              mapname = "chosen by a vote"})
+              end
+            end
+        end
+end )

--- a/lua/autorun/server/sv_tttvote.lua
+++ b/lua/autorun/server/sv_tttvote.lua
@@ -1,4 +1,4 @@
-hook.Add( "Initialize", "RTV", function()
+hook.Add( "Initialize", "AutoTTTMapVote", function()
         function CheckForMapSwitch()
            -- Check for mapswitch
            local rounds_left = math.max(0, GetGlobalInt("ttt_rounds_left", 6) - 1)
@@ -15,15 +15,9 @@ hook.Add( "Initialize", "RTV", function()
               LANG.Msg("limit_time", {mapname = nextmap})
               switchmap = true
             end
-            if GAMEMODE_NAME == "terrortown" then
-              if switchmap then
+            if GAMEMODE_NAME == "terrortown" and switchmap then
                 timer.Stop("end2prep")
                 MapVote.Start(nil, nil, nil, nil)
-              elseif ShouldMapSwitch() then
-                    LANG.Msg("limit_left", {num = rounds_left,
-                              time = math.ceil(time_left / 60),
-                              mapname = "chosen by a vote"})
-              end
             end
         end
 end )

--- a/lua/mapvote/cl_mapvote.lua
+++ b/lua/mapvote/cl_mapvote.lua
@@ -9,7 +9,7 @@ surface.CreateFont("RAM_VoteFont", {
 surface.CreateFont("RAM_VoteFontCountdown", {
     font = "Tahoma",
     size = 32,
-    weight = 700,v
+    weight = 700,
     antialias = true,
     shadow = true
 })

--- a/lua/mapvote/cl_mapvote.lua
+++ b/lua/mapvote/cl_mapvote.lua
@@ -74,6 +74,10 @@ net.Receive("RAM_MapVoteCancel", function()
     end
 end)
 
+net.Receive("RTV_Delay", function()
+    chat.AddText(Color( 102,255,51 ), "[RTV]", Color( 255,255,255 ), " The vote has been rocked, map vote will begin on round end")
+end)
+
 local PANEL = {}
 
 function PANEL:Init()

--- a/lua/mapvote/cl_mapvote.lua
+++ b/lua/mapvote/cl_mapvote.lua
@@ -9,7 +9,7 @@ surface.CreateFont("RAM_VoteFont", {
 surface.CreateFont("RAM_VoteFontCountdown", {
     font = "Tahoma",
     size = 32,
-    weight = 700,
+    weight = 700,v
     antialias = true,
     shadow = true
 })
@@ -43,7 +43,7 @@ net.Receive("RAM_MapVoteStart", function()
         MapVote.Panel:Remove()
     end
     
-    MapVote.Panel = vgui.Create("VoteScreen")
+    MapVote.Panel = vgui.Create("RAM_VoteScreen")
     MapVote.Panel:SetMaps(MapVote.CurrentMaps)
 end)
 
@@ -325,4 +325,4 @@ function PANEL:Flash(id)
     end
 end
 
-derma.DefineControl("VoteScreen", "", PANEL, "DPanel")
+derma.DefineControl("RAM_VoteScreen", "", PANEL, "DPanel")

--- a/lua/mapvote/cl_mapvote.lua
+++ b/lua/mapvote/cl_mapvote.lua
@@ -180,7 +180,7 @@ function PANEL:AddVoter(voter)
     icon_container:SetTooltip(voter:Name())
     icon:SetPlayer(voter, 16)
 
-    if MapVote.HasExtraVotePower(v) then
+    if MapVote.HasExtraVotePower(voter) then
         icon_container:SetSize(40, 20)
         icon:SetPos(21, 2)
         icon_container.img = star_mat
@@ -216,7 +216,7 @@ function PANEL:Think()
             else
                 local bar = self:GetMapButton(MapVote.Votes[v.Player:SteamID()])
                 
-                if(MapVote.HasExtraVotePower(v)) then
+                if(MapVote.HasExtraVotePower(v.Player)) then
                     bar.NumVotes = bar.NumVotes + 2
                 else
                     bar.NumVotes = bar.NumVotes + 1

--- a/lua/mapvote/cl_mapvote.lua
+++ b/lua/mapvote/cl_mapvote.lua
@@ -1,0 +1,324 @@
+surface.CreateFont("RAM_VoteFont", {
+    font = "Trebuchet MS",
+    size = 19,
+    weight = 700,
+    antialias = true,
+    shadow = true
+})
+
+surface.CreateFont("RAM_VoteFontCountdown", {
+    font = "Tahoma",
+    size = 32,
+    weight = 700,
+    antialias = true,
+    shadow = true
+})
+
+surface.CreateFont("RAM_VoteSysButton", 
+{    font = "Marlett",
+    size = 13,
+    weight = 0,
+    symbol = true,
+})
+
+MapVote.EndTime = 0
+MapVote.Panel = false
+
+net.Receive("RAM_MapVoteStart", function()
+    MapVote.CurrentMaps = {}
+    MapVote.Allow = true
+    MapVote.Votes = {}
+    
+    local amt = net.ReadUInt(32)
+    
+    for i = 1, amt do
+        local map = net.ReadString()
+        
+        MapVote.CurrentMaps[#MapVote.CurrentMaps + 1] = map
+    end
+    
+    MapVote.EndTime = CurTime() + net.ReadUInt(32)
+    
+    if(IsValid(MapVote.Panel)) then
+        MapVote.Panel:Remove()
+    end
+    
+    MapVote.Panel = vgui.Create("VoteScreen")
+    MapVote.Panel:SetMaps(MapVote.CurrentMaps)
+end)
+
+net.Receive("RAM_MapVoteUpdate", function()
+    local update_type = net.ReadUInt(3)
+    
+    if(update_type == MapVote.UPDATE_VOTE) then
+        local ply = net.ReadEntity()
+        
+        if(IsValid(ply)) then
+            local map_id = net.ReadUInt(32)
+            MapVote.Votes[ply:SteamID()] = map_id
+        
+            if(IsValid(MapVote.Panel)) then
+                MapVote.Panel:AddVoter(ply)
+            end
+        end
+    elseif(update_type == MapVote.UPDATE_WIN) then      
+        if(IsValid(MapVote.Panel)) then
+            MapVote.Panel:Flash(net.ReadUInt(32))
+        end
+    end
+end)
+
+net.Receive("RAM_MapVoteCancel", function()
+    if IsValid(MapVote.Panel) then
+        MapVote.Panel:Remove()
+    end
+end)
+
+local PANEL = {}
+
+function PANEL:Init()
+    self:ParentToHUD()
+    
+    self.Canvas = vgui.Create("Panel", self)
+    self.Canvas:MakePopup()
+    self.Canvas:SetKeyboardInputEnabled(false)
+    
+    self.countDown = vgui.Create("DLabel", self.Canvas)
+    self.countDown:SetTextColor(color_white)
+    self.countDown:SetFont("RAM_VoteFontCountdown")
+    self.countDown:SetText("")
+    self.countDown:SetPos(0, 14)
+    
+    self.mapList = vgui.Create("DPanelList", self.Canvas)
+    self.mapList:SetDrawBackground(false)
+    self.mapList:SetSpacing(4)
+    self.mapList:SetPadding(4)
+    self.mapList:EnableHorizontal(true)
+    self.mapList:EnableVerticalScrollbar()
+    
+    self.closeButton = vgui.Create("DButton", self.Canvas)
+    self.closeButton:SetText("")
+
+    self.closeButton.Paint = function(panel, w, h)
+        derma.SkinHook("Paint", "WindowCloseButton", panel, w, h)
+    end
+
+    self.closeButton.DoClick = function()
+        print("HI")
+        self:SetVisible(false)
+    end
+
+    self.maximButton = vgui.Create("DButton", self.Canvas)
+    self.maximButton:SetText("")
+    self.maximButton:SetDisabled(true)
+
+    self.maximButton.Paint = function(panel, w, h)
+        derma.SkinHook("Paint", "WindowMaximizeButton", panel, w, h)
+    end
+
+    self.minimButton = vgui.Create("DButton", self.Canvas)
+    self.minimButton:SetText("")
+    self.minimButton:SetDisabled(true)
+
+    self.minimButton.Paint = function(panel, w, h)
+        derma.SkinHook("Paint", "WindowMinimizeButton", panel, w, h)
+    end
+
+    self.Voters = {}
+end
+
+function PANEL:PerformLayout()
+    local cx, cy = chat.GetChatBoxPos()
+    
+    self:SetPos(0, 0)
+    self:SetSize(ScrW(), ScrH())
+    
+    local extra = math.Clamp(300, 0, ScrW() - 640)
+    self.Canvas:StretchToParent(0, 0, 0, 0)
+    self.Canvas:SetWide(640 + extra)
+    self.Canvas:SetTall(cy -60)
+    self.Canvas:SetPos(0, 0)
+    self.Canvas:CenterHorizontal()
+    self.Canvas:SetZPos(0)
+    
+    self.mapList:StretchToParent(0, 90, 0, 0)
+
+    local buttonPos = 640 + extra - 31 * 3
+
+    self.closeButton:SetPos(buttonPos - 31 * 0, 4)
+    self.closeButton:SetSize(31, 31)
+    self.closeButton:SetVisible(true)
+
+    self.maximButton:SetPos(buttonPos - 31 * 1, 4)
+    self.maximButton:SetSize(31, 31)
+    self.maximButton:SetVisible(true)
+
+    self.minimButton:SetPos(buttonPos - 31 * 2, 4)
+    self.minimButton:SetSize(31, 31)
+    self.minimButton:SetVisible(true)
+    
+end
+
+local heart_mat = Material("icon16/heart.png")
+local star_mat = Material("icon16/star.png")
+local shield_mat = Material("icon16/shield.png")
+
+function PANEL:AddVoter(voter)
+    for k, v in pairs(self.Voters) do
+        if(v.Player and v.Player == voter) then
+            return false
+        end
+    end
+    
+    
+    local icon_container = vgui.Create("Panel", self.mapList:GetCanvas())
+    local icon = vgui.Create("AvatarImage", icon_container)
+    icon:SetSize(16, 16)
+    icon:SetZPos(1000)
+    icon:SetTooltip(voter:Name())
+    icon_container.Player = voter
+    icon_container:SetTooltip(voter:Name())
+    icon:SetPlayer(voter, 16)
+
+    if MapVote.HasExtraVotePower(v) then
+        icon_container:SetSize(40, 20)
+        icon:SetPos(21, 2)
+        icon_container.img = star_mat
+    else
+        icon_container:SetSize(20, 20)
+        icon:SetPos(2, 2)
+    end
+    
+    icon_container.Paint = function(s, w, h)
+        draw.RoundedBox(4, 0, 0, w, h, Color(255, 0, 0, 80))
+        
+        if(icon_container.img) then
+            surface.SetMaterial(icon_container.img)
+            surface.SetDrawColor(Color(255, 255, 255))
+            surface.DrawTexturedRect(2, 2, 16, 16)
+        end
+    end
+    
+    table.insert(self.Voters, icon_container)
+end
+
+function PANEL:Think()
+    for k, v in pairs(self.mapList:GetItems()) do
+        v.NumVotes = 0
+    end
+    
+    for k, v in pairs(self.Voters) do
+        if(not IsValid(v.Player)) then
+            v:Remove()
+        else
+            if(not MapVote.Votes[v.Player:SteamID()]) then
+                v:Remove()
+            else
+                local bar = self:GetMapButton(MapVote.Votes[v.Player:SteamID()])
+                
+                if(MapVote.HasExtraVotePower(v)) then
+                    bar.NumVotes = bar.NumVotes + 2
+                else
+                    bar.NumVotes = bar.NumVotes + 1
+                end
+                
+                if(IsValid(bar)) then
+                    local CurrentPos = Vector(v.x, v.y, 0)
+                    local NewPos = Vector((bar.x + bar:GetWide()) - 21 * bar.NumVotes - 2, bar.y + (bar:GetTall() * 0.5 - 10), 0)
+                    
+                    if(not v.CurPos or v.CurPos ~= NewPos) then
+                        v:MoveTo(NewPos.x, NewPos.y, 0.3)
+                        v.CurPos = NewPos
+                    end
+                end
+            end
+        end
+        
+    end
+    
+    local timeLeft = math.Round(math.Clamp(MapVote.EndTime - CurTime(), 0, math.huge))
+    
+    self.countDown:SetText(tostring(timeLeft or 0).." seconds")
+    self.countDown:SizeToContents()
+    self.countDown:CenterHorizontal()
+end
+
+function PANEL:SetMaps(maps)
+    self.mapList:Clear()
+    
+    for k, v in RandomPairs(maps) do
+        local button = vgui.Create("DButton", self.mapList)
+        button.ID = k
+        button:SetText(v)
+        
+        button.DoClick = function()
+            net.Start("RAM_MapVoteUpdate")
+                net.WriteUInt(MapVote.UPDATE_VOTE, 3)
+                net.WriteUInt(button.ID, 32)
+            net.SendToServer()
+        end
+        
+        do
+            local Paint = button.Paint
+            button.Paint = function(s, w, h)
+                local col = Color(255, 255, 255, 10)
+                
+                if(button.bgColor) then
+                    col = button.bgColor
+                end
+                
+                draw.RoundedBox(4, 0, 0, w, h, col)
+                Paint(s, w, h)
+            end
+        end
+        
+        button:SetTextColor(color_white)
+        button:SetContentAlignment(4)
+        button:SetTextInset(8, 0)
+        button:SetFont("RAM_VoteFont")
+        
+        local extra = math.Clamp(300, 0, ScrW() - 640)
+        
+        button:SetDrawBackground(false)
+        button:SetTall(24)
+        button:SetWide(285 + (extra / 2))
+        button.NumVotes = 0
+        
+        self.mapList:AddItem(button)
+    end
+end
+
+function PANEL:GetMapButton(id)
+    for k, v in pairs(self.mapList:GetItems()) do
+        if(v.ID == id) then return v end
+    end
+    
+    return false
+end
+
+function PANEL:Paint()
+    --Derma_DrawBackgroundBlur(self)
+    
+    local CenterY = ScrH() / 2
+    local CenterX = ScrW() / 2
+    
+    surface.SetDrawColor(0, 0, 0, 200)
+    surface.DrawRect(0, 0, ScrW(), ScrH())
+end
+
+function PANEL:Flash(id)
+    self:SetVisible(true)
+
+    local bar = self:GetMapButton(id)
+    
+    if(IsValid(bar)) then
+        timer.Simple( 0.0, function() bar.bgColor = Color( 0, 255, 255 ) surface.PlaySound( "hl1/fvox/blip.wav" ) end )
+        timer.Simple( 0.2, function() bar.bgColor = nil end )
+        timer.Simple( 0.4, function() bar.bgColor = Color( 0, 255, 255 ) surface.PlaySound( "hl1/fvox/blip.wav" ) end )
+        timer.Simple( 0.6, function() bar.bgColor = nil end )
+        timer.Simple( 0.8, function() bar.bgColor = Color( 0, 255, 255 ) surface.PlaySound( "hl1/fvox/blip.wav" ) end )
+        timer.Simple( 1.0, function() bar.bgColor = Color( 100, 100, 100 ) end )
+    end
+end
+
+derma.DefineControl("VoteScreen", "", PANEL, "DPanel")

--- a/lua/mapvote/rtv.lua
+++ b/lua/mapvote/rtv.lua
@@ -63,7 +63,8 @@ hook.Add( "PlayerDisconnected", "Remove RTV", function( ply )
 end )
 
 function RTV.CanVote( ply )
-
+	local plyCount = table.Count(player.GetAll())
+	
 	if RTV._ActualWait >= CurTime() then
 		return false, "You must wait a bit before voting!"
 	end

--- a/lua/mapvote/rtv.lua
+++ b/lua/mapvote/rtv.lua
@@ -1,0 +1,115 @@
+RTV = RTV or {}
+
+RTV.ChatCommands = {
+	
+	"!rtv",
+	"/rtv",
+	"rtv"
+
+}
+
+RTV.TotalVotes = 0
+
+RTV.Wait = 60 -- The wait time in seconds. This is how long a player has to wait before voting when the map changes. 
+			  -- If the "extend" option is picked, you have to wait double this before voting again.
+
+
+RTV._ActualWait = CurTime() + RTV.Wait
+
+
+
+function RTV.ShouldChange()
+	return RTV.TotalVotes >= math.Round(#player.GetAll()*0.66)
+end
+
+function RTV.RemoveVote()
+	RTV.TotalVotes = math.Clamp( RTV.TotalVotes - 1, 0, math.huge )
+end
+
+function RTV.Start()
+local current = current or MapVote.Config.AllowCurrentMap or false
+local length = length or MapVote.Config.TimeLimit or 28
+local limit = limit or MapVote.Config.MapLimit or 24
+local prefixes = prefixes or Mapvote.Config.MapPrefixes or "{"ttt"}"
+
+MapVote.Start(length, current, limit, prefixes)
+
+end
+
+
+function RTV.AddVote( ply )
+
+	if RTV.CanVote( ply ) then
+		RTV.TotalVotes = RTV.TotalVotes + 1
+		ply.RTVoted = true
+		MsgN( ply:Nick().." has voted to Rock the Vote." )
+		PrintMessage( HUD_PRINTTALK, ply:Nick().." has voted to Rock the Vote. ("..RTV.TotalVotes.."/"..math.Round(#player.GetAll()*0.66)..")" )
+
+		if RTV.ShouldChange() then
+			RTV.Start()
+		end
+	end
+
+end
+
+hook.Add( "PlayerDisconnected", "Remove RTV", function( ply )
+
+	if ply.RTVoted then
+		RTV.RemoveVote()
+	end
+
+	timer.Simple( 0.1, function()
+
+		if RTV.ShouldChange() then
+			RTV.Start()
+		end
+
+	end )
+
+end )
+
+function RTV.CanVote( ply )
+
+	if RTV._ActualWait >= CurTime() then
+		return false, "You must wait a bit before voting!"
+	end
+
+	if GetGlobalBool( "In_Voting" ) then
+		return false, "There is currently a vote in progress!"
+	end
+
+	if ply.RTVoted then
+		return false, "You have already voted to Rock the Vote!"
+	end
+
+	if RTV.ChangingMaps then
+		return false, "There has already been a vote, the map is going to change!"
+	end
+
+	return true
+
+end
+
+function RTV.StartVote( ply )
+
+	local can, err = RTV.CanVote(ply)
+
+	if not can then
+		ply:PrintMessage( HUD_PRINTTALK, err )
+		return
+	end
+
+	RTV.AddVote( ply )
+
+end
+
+concommand.Add( "rtv_start", RTV.StartVote )
+
+hook.Add( "PlayerSay", "RTV Chat Commands", function( ply, text )
+
+	if table.HasValue( RTV.ChatCommands, string.lower(text) ) then
+		RTV.StartVote( ply )
+		return ""
+	end
+
+end )

--- a/lua/mapvote/rtv.lua
+++ b/lua/mapvote/rtv.lua
@@ -28,7 +28,7 @@ end
 
 function RTV.Start()
 
-MapVote.Start(length, current, limit, {"ttt_"})
+MapVote.Start(nil, nil, nil, nil)
 
 end
 

--- a/lua/mapvote/rtv.lua
+++ b/lua/mapvote/rtv.lua
@@ -25,20 +25,22 @@ function RTV.RemoveVote()
 end
 
 function RTV.Start()
-			if GAMEMODE.Name == "Trouble in Terrorist Town" then
-				chat.AddText(color( 102,255,51 ), "[RTV]", Color( 255,255,255 ), " The vote has been rocked, map vote will begin on round end")
+			if GAMEMODE_NAME == "terrortown" then
+				net.Start("RTV_Delay")
+        		net.Broadcast()
  
 				hook.Add("TTTEndRound", "MapvoteDelayed", function()
 					MapVote.Start(nil, nil, nil, nil)
 				end)
-			elseif GAMEMODE.name == "Deathrun" then
-				chat.AddText(color( 102,255,51 ), "[RTV]", Color( 255,255,255 ), " The vote has been rocked, map vote will begin on round end")
- 
+			elseif GAMEMODE_NAME == "deathrun" then
+				net.Start("RTV_Delay")
+        		net.Broadcast()
+
 				hook.Add("RoundEnd", "MapvoteDelayed", function()
 					MapVote.Start(nil, nil, nil, nil)
 				end)
 			else
-				chat.AddText(color( 102,255,51 ), "[RTV]", Color( 255,255,255 ), " The vote has been rocked, map vote imminent")
+				PrintMessage( HUD_PRINTTALK, "The vote has been rocked, map vote imminent")
 				timer.Simple(4, function()
 					MapVote.Start(nil, nil, nil, nil)
 				end)

--- a/lua/mapvote/rtv.lua
+++ b/lua/mapvote/rtv.lua
@@ -11,12 +11,10 @@ RTV.ChatCommands = {
 RTV.TotalVotes = 0
 
 RTV.Wait = 60 -- The wait time in seconds. This is how long a player has to wait before voting when the map changes. 
-			  -- If the "extend" option is picked, you have to wait double this before voting again.
-
 
 RTV._ActualWait = CurTime() + RTV.Wait
 
-
+RTV.PlayerCount = MapVote.Config.RTVPlayerCount or 3
 
 function RTV.ShouldChange()
 	return RTV.TotalVotes >= math.Round(#player.GetAll()*0.66)
@@ -81,6 +79,9 @@ function RTV.CanVote( ply )
 	if RTV.ChangingMaps then
 		return false, "There has already been a vote, the map is going to change!"
 	end
+	if plyCount < RTV.PlayerCount then
+        return false, "You need more players before you can rock the vote!"
+    end
 
 	return true
 

--- a/lua/mapvote/rtv.lua
+++ b/lua/mapvote/rtv.lua
@@ -25,9 +25,24 @@ function RTV.RemoveVote()
 end
 
 function RTV.Start()
-
-MapVote.Start(nil, nil, nil, nil)
-
+			if GAMEMODE.Name == "Trouble in Terrorist Town" then
+				chat.AddText(color( 102,255,51 ), "[RTV]", Color( 255,255,255 ), " The vote has been rocked, map vote will begin on round end")
+ 
+				hook.Add("TTTEndRound", "MapvoteDelayed", function()
+					MapVote.Start(nil, nil, nil, nil)
+				end)
+			elseif GAMEMODE.name == "Deathrun" then
+				chat.AddText(color( 102,255,51 ), "[RTV]", Color( 255,255,255 ), " The vote has been rocked, map vote will begin on round end")
+ 
+				hook.Add("RoundEnd", "MapvoteDelayed", function()
+					MapVote.Start(nil, nil, nil, nil)
+				end)
+			else
+				chat.AddText(color( 102,255,51 ), "[RTV]", Color( 255,255,255 ), " The vote has been rocked, map vote imminent")
+				timer.Simple(4, function()
+					MapVote.Start(nil, nil, nil, nil)
+				end)
+			end
 end
 
 

--- a/lua/mapvote/rtv.lua
+++ b/lua/mapvote/rtv.lua
@@ -27,12 +27,8 @@ function RTV.RemoveVote()
 end
 
 function RTV.Start()
-local current = current or MapVote.Config.AllowCurrentMap or false
-local length = length or MapVote.Config.TimeLimit or 28
-local limit = limit or MapVote.Config.MapLimit or 24
-local prefixes = prefixes or Mapvote.Config.MapPrefixes or "{"ttt"}"
 
-MapVote.Start(length, current, limit, prefixes)
+MapVote.Start(length, current, limit, {"ttt_"})
 
 end
 

--- a/lua/mapvote/sv_mapvote.lua
+++ b/lua/mapvote/sv_mapvote.lua
@@ -26,11 +26,38 @@ net.Receive("RAM_MapVoteUpdate", function(len, ply)
     end
 end)
 
+recentmaps = {}
+
+function inTable(tbl, item)
+    for key, value in pairs(tbl) do
+        if value == item then
+            return true
+        end
+    end
+    return false
+end
+
+cooldownnum = MapVote.Config.MapsBeforeRevote or 3
+
+function CoolDownDoStuff()
+        if table.getn(recentmaps) == cooldownnum then 
+            table.remove(recentmaps)
+        end
+        local curmap = game.GetMap():lower()..".bsp"
+        if not inTable(recentmaps, curmap) then
+            table.insert(recentmaps, 1, curmap)
+        end
+end
+
+if cooldown then
+    hook.Add( "Initialize", "Ion_Add_Recent", CoolDownDoStuff )
+end
 
 function MapVote.Start(length, current, limit, prefix)
     current = current or MapVote.Config.AllowCurrentMap or false
     length = length or MapVote.Config.TimeLimit or 28
     limit = limit or MapVote.Config.MapLimit or 24
+    cooldown = MapVote.Config.EnableCooldown or true
 
     local is_expression = false
 
@@ -60,6 +87,7 @@ function MapVote.Start(length, current, limit, prefix)
     for k, map in RandomPairs(maps) do
         local mapstr = map:sub(1, -5):lower()
         if(not current and game.GetMap():lower()..".bsp" == map) then continue end
+        if(cooldown and inTable(recentmaps, map)) then end
 
         if is_expression then
             if(string.find(map, prefix)) then -- This might work (from gamemode.txt)

--- a/lua/mapvote/sv_mapvote.lua
+++ b/lua/mapvote/sv_mapvote.lua
@@ -37,9 +37,8 @@ function inTable(tbl, item)
     return false
 end
 
-cooldownnum = MapVote.Config.MapsBeforeRevote or 3
-
 function CoolDownDoStuff()
+    cooldownnum = MapVote.Config.MapsBeforeRevote or 3
         if table.getn(recentmaps) == cooldownnum then 
             table.remove(recentmaps)
         end

--- a/lua/mapvote/sv_mapvote.lua
+++ b/lua/mapvote/sv_mapvote.lua
@@ -104,7 +104,7 @@ function MapVote.Start(length, current, limit, prefix)
             
             for k2, v2 in pairs(player.GetAll()) do
                 if(v2:SteamID() == k) then
-                    if(MapVote.HasExtraVotePower(v)) then
+                    if(MapVote.HasExtraVotePower(v2)) then
                         map_results[v] = map_results[v] + 2
                     else
                         map_results[v] = map_results[v] + 1

--- a/lua/mapvote/sv_mapvote.lua
+++ b/lua/mapvote/sv_mapvote.lua
@@ -1,0 +1,144 @@
+util.AddNetworkString("RAM_MapVoteStart")
+util.AddNetworkString("RAM_MapVoteUpdate")
+util.AddNetworkString("RAM_MapVoteCancel")
+
+MapVote.Continued = false
+
+net.Receive("RAM_MapVoteUpdate", function(len, ply)
+    if(MapVote.Allow) then
+        if(IsValid(ply)) then
+            local update_type = net.ReadUInt(3)
+            
+            if(update_type == MapVote.UPDATE_VOTE) then
+                local map_id = net.ReadUInt(32)
+                
+                if(MapVote.CurrentMaps[map_id]) then
+                    MapVote.Votes[ply:SteamID()] = map_id
+                    
+                    net.Start("RAM_MapVoteUpdate")
+                        net.WriteUInt(MapVote.UPDATE_VOTE, 3)
+                        net.WriteEntity(ply)
+                        net.WriteUInt(map_id, 32)
+                    net.Broadcast()
+                end
+            end
+        end
+    end
+end)
+
+
+function MapVote.Start(length, current, limit, prefix)
+    current = current or MapVote.Config.AllowCurrentMap or false
+    length = length or MapVote.Config.TimeLimit or 28
+    limit = limit or MapVote.Config.MapLimit or 24
+
+    local is_expression = false
+
+    if not prefix then
+        local info = file.Read(GAMEMODE.Folder.."/"..GAMEMODE.FolderName..".txt", "GAME")
+
+        if(info) then
+            local info = util.KeyValuesToTable(info)
+            prefix = info.maps
+        else
+            error("MapVote Prefix can not be loaded from gamemode")
+        end
+
+        is_expression = true
+    else
+        if prefix and type(prefix) ~= "table" then
+            prefix = {prefix}
+        end
+    end
+    
+    local maps = file.Find("maps/*.bsp", "GAME")
+    
+    local vote_maps = {}
+    
+    local amt = 0
+
+    for k, map in RandomPairs(maps) do
+        local mapstr = map:sub(1, -5):lower()
+        if(not current and game.GetMap():lower()..".bsp" == map) then continue end
+
+        if is_expression then
+            if(string.find(map, prefix)) then -- This might work (from gamemode.txt)
+                vote_maps[#vote_maps + 1] = map:sub(1, -5)
+                amt = amt + 1
+            end
+        else
+            for k, v in pairs(prefix) do
+                if string.find(map, "^"..v) then
+                    vote_maps[#vote_maps + 1] = map:sub(1, -5)
+                    amt = amt + 1
+                    break
+                end
+            end
+        end
+        
+        if(limit and amt >= limit) then break end
+    end
+    
+    net.Start("RAM_MapVoteStart")
+        net.WriteUInt(#vote_maps, 32)
+        
+        for i = 1, #vote_maps do
+            net.WriteString(vote_maps[i])
+        end
+        
+        net.WriteUInt(length, 32)
+    net.Broadcast()
+    
+    MapVote.Allow = true
+    MapVote.CurrentMaps = vote_maps
+    MapVote.Votes = {}
+    
+    timer.Create("RAM_MapVote", length, 1, function()
+        MapVote.Allow = false
+        local map_results = {}
+        
+        for k, v in pairs(MapVote.Votes) do
+            if(not map_results[v]) then
+                map_results[v] = 0
+            end
+            
+            for k2, v2 in pairs(player.GetAll()) do
+                if(v2:SteamID() == k) then
+                    if(MapVote.HasExtraVotePower(v)) then
+                        map_results[v] = map_results[v] + 2
+                    else
+                        map_results[v] = map_results[v] + 1
+                    end
+                end
+            end
+            
+        end
+        
+        local winner = table.GetWinningKey(map_results) or 1
+        
+        net.Start("RAM_MapVoteUpdate")
+            net.WriteUInt(MapVote.UPDATE_WIN, 3)
+            
+            net.WriteUInt(winner, 32)
+        net.Broadcast()
+        
+        local map = MapVote.CurrentMaps[winner]
+
+        
+        timer.Simple(4, function()
+            hook.Run("MapVoteChange", map)
+            RunConsoleCommand("changelevel", map)
+        end)
+    end)
+end
+
+function MapVote.Cancel()
+    if MapVote.Allow then
+        MapVote.Allow = false
+
+        net.Start("RAM_MapVoteCancel")
+        net.Broadcast()
+
+        timer.Destroy("RAM_MapVote")
+    end
+end

--- a/lua/mapvote/sv_mapvote.lua
+++ b/lua/mapvote/sv_mapvote.lua
@@ -26,8 +26,6 @@ net.Receive("RAM_MapVoteUpdate", function(len, ply)
     end
 end)
 
-recentmaps = {}
-
 function inTable(tbl, item)
     for key, value in pairs(tbl) do
         if value == item then
@@ -36,6 +34,14 @@ function inTable(tbl, item)
     end
     return false
 end
+
+if file.Exists( "recentmaps.txt", "DATA" ) then
+    recentmaps = util.JSONToTable(file.Read("recentmaps.txt"))
+else
+    recentmaps = {}
+end
+
+cooldown = MapVote.Config.EnableCooldown or true
 
 function CoolDownDoStuff()
     cooldownnum = MapVote.Config.MapsBeforeRevote or 3
@@ -46,6 +52,7 @@ function CoolDownDoStuff()
         if not inTable(recentmaps, curmap) then
             table.insert(recentmaps, 1, curmap)
         end
+    file.Write("recentmaps.txt", util.TableToJSON(recentmaps))
 end
 
 if cooldown then
@@ -56,7 +63,6 @@ function MapVote.Start(length, current, limit, prefix)
     current = current or MapVote.Config.AllowCurrentMap or false
     length = length or MapVote.Config.TimeLimit or 28
     limit = limit or MapVote.Config.MapLimit or 24
-    cooldown = MapVote.Config.EnableCooldown or true
 
     local is_expression = false
 

--- a/lua/mapvote/sv_mapvote.lua
+++ b/lua/mapvote/sv_mapvote.lua
@@ -36,7 +36,7 @@ function inTable(tbl, item)
 end
 
 if file.Exists( "recentmaps.txt", "DATA" ) then
-    recentmaps = util.JSONToTable(file.Read("recentmaps.txt"))
+    recentmaps = util.JSONToTable(file.Read("recentmaps.txt", "DATA"))
 else
     recentmaps = {}
 end
@@ -45,13 +45,17 @@ cooldown = MapVote.Config.EnableCooldown or true
 
 function CoolDownDoStuff()
     cooldownnum = MapVote.Config.MapsBeforeRevote or 3
-        if table.getn(recentmaps) == cooldownnum then 
-            table.remove(recentmaps)
-        end
-        local curmap = game.GetMap():lower()..".bsp"
-        if not inTable(recentmaps, curmap) then
-            table.insert(recentmaps, 1, curmap)
-        end
+
+    if table.getn(recentmaps) == cooldownnum then 
+        table.remove(recentmaps)
+    end
+
+    local curmap = game.GetMap():lower()..".bsp"
+
+    if not inTable(recentmaps, curmap) then
+        table.insert(recentmaps, 1, curmap)
+    end
+
     file.Write("recentmaps.txt", util.TableToJSON(recentmaps))
 end
 

--- a/lua/mapvote/sv_mapvote.lua
+++ b/lua/mapvote/sv_mapvote.lua
@@ -1,6 +1,7 @@
 util.AddNetworkString("RAM_MapVoteStart")
 util.AddNetworkString("RAM_MapVoteUpdate")
 util.AddNetworkString("RAM_MapVoteCancel")
+util.AddNetworkString("RTV_Delay")
 
 MapVote.Continued = false
 
@@ -59,7 +60,7 @@ function MapVote.Start(length, current, limit, prefix)
     length = length or MapVote.Config.TimeLimit or 28
     limit = limit or MapVote.Config.MapLimit or 24
     cooldown = MapVote.Config.EnableCooldown or true
-    prefix = prefix or MapVote.Config.MapPrefixes or {"ttt_"}
+    prefix = prefix or MapVote.Config.MapPrefixes
 
     local is_expression = false
 

--- a/lua/mapvote/sv_mapvote.lua
+++ b/lua/mapvote/sv_mapvote.lua
@@ -26,8 +26,8 @@ net.Receive("RAM_MapVoteUpdate", function(len, ply)
     end
 end)
 
-if file.Exists( "recentmaps.txt", "DATA" ) then
-    recentmaps = util.JSONToTable(file.Read("recentmaps.txt", "DATA"))
+if file.Exists( "mapvote/recentmaps.txt", "DATA" ) then
+    recentmaps = util.JSONToTable(file.Read("mapvote/recentmaps.txt", "DATA"))
 else
     recentmaps = {}
 end
@@ -45,7 +45,7 @@ function CoolDownDoStuff()
         table.insert(recentmaps, 1, curmap)
     end
 
-    file.Write("recentmaps.txt", util.TableToJSON(recentmaps))
+    file.Write("mapvote/recentmaps.txt", util.TableToJSON(recentmaps))
 end
 
 function MapVote.Start(length, current, limit, prefix)
@@ -53,7 +53,8 @@ function MapVote.Start(length, current, limit, prefix)
     length = length or MapVote.Config.TimeLimit or 28
     limit = limit or MapVote.Config.MapLimit or 24
     cooldown = MapVote.Config.EnableCooldown or true
-    
+    prefix = prefix or MapVote.Config.MapPrefixes or {"ttt_"}
+
     local is_expression = false
 
     if not prefix then
@@ -157,6 +158,12 @@ function MapVote.Start(length, current, limit, prefix)
         end)
     end)
 end
+
+hook.Add( "Shutdown", "RemoveRecentMaps", function()
+        if file.Exists( "mapvote/recentmaps.txt", "DATA" ) then
+            file.Delete( "mapvote/recentmaps.txt" )
+        end
+end )
 
 function MapVote.Cancel()
     if MapVote.Allow then

--- a/lua/mapvote/sv_mapvote.lua
+++ b/lua/mapvote/sv_mapvote.lua
@@ -32,6 +32,12 @@ else
     recentmaps = {}
 end
 
+if file.Exists( "mapvote/config.txt", "DATA" ) then
+    MapVote.Config = util.JSONToTable(file.Read("mapvote/config.txt", "DATA"))
+else
+    MapVote.Config = {}
+end
+
 function CoolDownDoStuff()
     cooldownnum = MapVote.Config.MapsBeforeRevote or 3
 

--- a/lua/ulx/modules/sh/mapvote.lua
+++ b/lua/ulx/modules/sh/mapvote.lua
@@ -1,0 +1,18 @@
+local CATEGORY_NAME = "MapVote"
+------------------------------ VoteMap ------------------------------
+function AMB_mapvote( calling_ply, votetime, should_cancel )
+	if not should_cancel then
+		MapVote.Start(votetime, nil, nil, nil)
+		ulx.fancyLogAdmin( calling_ply, "#A called a votemap!" )
+	else
+		MapVote.Cancel()
+		ulx.fancyLogAdmin( calling_ply, "#A canceled the votemap" )
+	end
+end
+
+local mapvotecmd = ulx.command( CATEGORY_NAME, "mapvote", AMB_mapvote, "!mapvote" )
+mapvotecmd:addParam{ type=ULib.cmds.NumArg, min=15, default=25, hint="time", ULib.cmds.optional, ULib.cmds.round }
+mapvotecmd:addParam{ type=ULib.cmds.BoolArg, invisible=true }
+mapvotecmd:defaultAccess( ULib.ACCESS_ADMIN )
+mapvotecmd:help( "Invokes the map vote logic" )
+mapvotecmd:setOpposite( "unmapvote", {_, _, true}, "!unmapvote" )


### PR DESCRIPTION
A simple change which implements the ULX system for doing this.
Use case is for example a server which has content packs from the workshop added (which means removing them from the actual machine is a PITA) but doesn't want certain maps played.
The way I've done this will not break if ULX (or at least its config file) isn't present, and should allow additions for other ban or allow lists (even one specific to this addon if wanted) easily.